### PR TITLE
fix webhook config

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 <div align="center">
 
-# Conekta Woocommerce v.5.0.1
+# Conekta Woocommerce v.5.0.2
 [![Made with PHP](https://img.shields.io/badge/made%20with-php-red.svg?style=for-the-badge&colorA=ED4040&colorB=C12C2D)](http://php.net) 
 [![By Conekta](https://img.shields.io/badge/by-conekta-red.svg?style=for-the-badge&colorA=ee6130&colorB=00a4ac)](https://conekta.com)
 </div>

--- a/composer.json
+++ b/composer.json
@@ -12,6 +12,6 @@
         }
     ],
     "require": {
-        "conekta/conekta-php": "6.0.6"
+        "conekta/conekta-php": "6.0.7"
     }
 }

--- a/composer.lock
+++ b/composer.lock
@@ -4,20 +4,20 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "9b745e67d89904d47b5cf25a7d6382f9",
+    "content-hash": "687c20c337a318840bad1146d995d2db",
     "packages": [
         {
             "name": "conekta/conekta-php",
-            "version": "6.0.6",
+            "version": "6.0.7",
             "source": {
                 "type": "git",
                 "url": "https://github.com/conekta/conekta-php.git",
-                "reference": "edd677bf7fd6039db8c3cbb97b5ee38272046acd"
+                "reference": "ed28e0e080c5f9751fd27cf1d08f8012a80e2e09"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/conekta/conekta-php/zipball/edd677bf7fd6039db8c3cbb97b5ee38272046acd",
-                "reference": "edd677bf7fd6039db8c3cbb97b5ee38272046acd",
+                "url": "https://api.github.com/repos/conekta/conekta-php/zipball/ed28e0e080c5f9751fd27cf1d08f8012a80e2e09",
+                "reference": "ed28e0e080c5f9751fd27cf1d08f8012a80e2e09",
                 "shasum": ""
             },
             "require": {
@@ -30,7 +30,7 @@
             },
             "require-dev": {
                 "friendsofphp/php-cs-fixer": "^3.5",
-                "phpstan/phpstan": "1.10.57",
+                "phpstan/phpstan": "1.10.63",
                 "phpunit/phpunit": "^9.0 || ^10.0"
             },
             "type": "library",
@@ -60,9 +60,9 @@
             ],
             "support": {
                 "issues": "https://github.com/conekta/conekta-php/issues",
-                "source": "https://github.com/conekta/conekta-php/tree/v6.0.6"
+                "source": "https://github.com/conekta/conekta-php/tree/v6.0.7"
             },
-            "time": "2024-02-13T19:20:49+00:00"
+            "time": "2024-03-21T23:52:14+00:00"
         },
         {
             "name": "guzzlehttp/guzzle",
@@ -669,5 +669,5 @@
     "prefer-lowest": false,
     "platform": [],
     "platform-dev": [],
-    "plugin-api-version": "2.3.0"
+    "plugin-api-version": "2.6.0"
 }

--- a/conekta_bank_transfer_block_gateway.php
+++ b/conekta_bank_transfer_block_gateway.php
@@ -27,10 +27,11 @@ class WC_Conekta_Bank_Transfer_Gateway extends WC_Conekta_Plugin
     public $title;
     public $description;
     public $api_key;
-    public string $webhook_url;
+    public $webhook_url;
 
     /**
      * @throws ApiException
+     * @throws Exception
      */
     public function __construct()
     {

--- a/conekta_bank_transfer_block_gateway.php
+++ b/conekta_bank_transfer_block_gateway.php
@@ -57,7 +57,7 @@ class WC_Conekta_Bank_Transfer_Gateway extends WC_Conekta_Plugin
             $this->enabled = false;
         }
         if ($this->enabled) {
-            $this->enabled= self::create_webhook( $this->api_key, $this->webhook_url);
+            self::create_webhook( $this->api_key, $this->webhook_url);
         }
     }
     /**

--- a/conekta_bank_transfer_block_gateway.php
+++ b/conekta_bank_transfer_block_gateway.php
@@ -13,6 +13,7 @@ use Conekta\ApiException;
 use \Conekta\Configuration;
 use Conekta\Model\OrderRequest;
 use Conekta\Model\CustomerShippingContacts;
+use Conekta\Model\EventTypes;
 
 class WC_Conekta_Bank_Transfer_Gateway extends WC_Conekta_Plugin
 {
@@ -26,7 +27,11 @@ class WC_Conekta_Bank_Transfer_Gateway extends WC_Conekta_Plugin
     public $title;
     public $description;
     public $api_key;
+    public string $webhook_url;
 
+    /**
+     * @throws ApiException
+     */
     public function __construct()
     {
         $this->id = 'conekta_bank_transfer';
@@ -37,15 +42,56 @@ class WC_Conekta_Bank_Transfer_Gateway extends WC_Conekta_Plugin
         $this->title = $this->settings['title'];
         $this->description = $this->settings['description'];
         $this->api_key = $this->settings['api_key'];
+        $this->webhook_url = $this->settings['webhook_url'];
 
         add_action('woocommerce_update_options_payment_gateways_' . $this->id, array($this, 'process_admin_options'));
         add_action('woocommerce_thankyou_' . $this->id, array($this, 'ckpg_thankyou_page'));
+        add_action('woocommerce_api_wc_conekta_bank_transfer', [$this, 'check_for_webhook']);
+
         if (!$this->ckpg_validate_currency()) {
             $this->enabled = false;
         }
 
         if (empty($this->api_key)) {
             $this->enabled = false;
+        }
+        if ($this->enabled) {
+            $this->enabled= self::create_webhook( $this->api_key, $this->webhook_url);
+        }
+    }
+    /**
+     * @throws ApiException
+     */
+    public function check_for_webhook()
+    {
+        if (!isset($_SERVER['REQUEST_METHOD'])
+            || ('POST' !== $_SERVER['REQUEST_METHOD'])
+            || !isset($_GET['wc-api'])
+            || ('wc_conekta_bank_transfer' !== $_GET['wc-api'])
+        ) {
+            return;
+        }
+
+        $body = @file_get_contents('php://input');
+        $event = json_decode($body, true);
+
+        switch ($event['type']) {
+            case EventTypes::WEBHOOK_PING:
+                self::handleWebhookPing();
+                break;
+
+            case EventTypes::ORDER_PAID:
+                self::check_if_payment_payment_method_webhook($this->GATEWAY_NAME, $event);
+                self::handleOrderPaid($this->get_api_instance(), $event);
+                break;
+
+            case EventTypes::ORDER_EXPIRED:
+            case EventTypes::ORDER_CANCELED:
+                self::check_if_payment_payment_method_webhook($this->GATEWAY_NAME, $event);
+                self::handleOrderExpiredOrCanceled($this->get_api_instance(),$event);
+                break;
+            default:
+                break;
         }
     }
 
@@ -121,6 +167,13 @@ class WC_Conekta_Bank_Transfer_Gateway extends WC_Conekta_Plugin
                     'max' => 30,
                     'step' => 1
                 ),
+            ),
+            'webhook_url' => array(
+                'type' => 'text',
+                'title' => __('URL webhook', 'woothemes'),
+                'description' => __('URL webhook)', 'woothemes'),
+                'default' => __(get_site_url() . '/?wc-api=wc_conekta_bank_transfer'),
+                'required' => true
             )
         );
 
@@ -155,7 +208,8 @@ class WC_Conekta_Bank_Transfer_Gateway extends WC_Conekta_Plugin
         $customer_info = ckpg_build_customer_info($data);
         $order_metadata = ckpg_build_order_metadata($data + array(
                 'plugin_conekta_version' => $this->version,
-                'woocommerce_version' => $woocommerce->version
+                'woocommerce_version' => $woocommerce->version,
+                'payment_method' => $this->GATEWAY_NAME,
             )
         );
         $rq = new OrderRequest([

--- a/conekta_block_gateway.php
+++ b/conekta_block_gateway.php
@@ -27,10 +27,10 @@ class WC_Conekta_Gateway extends WC_Conekta_Plugin
     public $title;
     public $description;
     public $api_key;
-    public string $webhook_url;
+    public $webhook_url;
 
     /**
-     * @throws ApiException
+     * @throws ApiException|Exception
      */
     public function __construct()
     {

--- a/conekta_block_gateway.php
+++ b/conekta_block_gateway.php
@@ -54,7 +54,7 @@ class WC_Conekta_Gateway extends WC_Conekta_Plugin
             $this->enabled = false;
         }
         if ($this->enabled) {
-            $this->enabled= self::create_webhook( $this->api_key, $this->webhook_url);
+             self::create_webhook( $this->api_key, $this->webhook_url);
         }
     }
 

--- a/conekta_block_gateway.php
+++ b/conekta_block_gateway.php
@@ -27,7 +27,11 @@ class WC_Conekta_Gateway extends WC_Conekta_Plugin
     public $title;
     public $description;
     public $api_key;
+    public string $webhook_url;
 
+    /**
+     * @throws ApiException
+     */
     public function __construct()
     {
         $this->id = 'conekta';
@@ -38,6 +42,7 @@ class WC_Conekta_Gateway extends WC_Conekta_Plugin
         $this->title = $this->settings['title'];
         $this->description = $this->settings['description'];
         $this->api_key = $this->settings['cards_api_key'];
+        $this->webhook_url = $this->settings['webhook_url'];
 
         add_action('woocommerce_update_options_payment_gateways_' . $this->id, array($this, 'process_admin_options'));
         add_action('woocommerce_api_wc_conekta', [$this, 'check_for_webhook']);
@@ -47,6 +52,9 @@ class WC_Conekta_Gateway extends WC_Conekta_Plugin
 
         if (empty($this->api_key)) {
             $this->enabled = false;
+        }
+        if ($this->enabled) {
+            $this->enabled= self::create_webhook( $this->api_key, $this->webhook_url);
         }
     }
 
@@ -68,102 +76,24 @@ class WC_Conekta_Gateway extends WC_Conekta_Plugin
 
         switch ($event['type']) {
             case EventTypes::WEBHOOK_PING:
-                $this->handleWebhookPing();
+                self::handleWebhookPing();
                 break;
 
             case EventTypes::ORDER_PAID:
-                $this->handleOrderPaid($event);
+                self::check_if_payment_payment_method_webhook($this->GATEWAY_NAME, $event);
+                self::handleOrderPaid($this->get_api_instance(), $event);
                 break;
 
             case EventTypes::ORDER_EXPIRED:
             case EventTypes::ORDER_CANCELED:
-                $this->handleOrderExpiredOrCanceled($event);
+                self::check_if_payment_payment_method_webhook($this->GATEWAY_NAME, $event);
+                self::handleOrderExpiredOrCanceled($this->get_api_instance(),$event);
                 break;
             default:
                 break;
         }
     }
 
-    /**
-     * @throws ApiException
-     */
-    private function handleOrderExpiredOrCanceled($event)
-    {
-        $conekta_order = $event['data']['object'];
-        if (!$this->validate_reference_id($conekta_order)) {
-            http_response_code(400);
-            header('Content-Type: application/json');
-            echo json_encode(['error' => 'Invalid order id']);
-            exit;
-        }
-        $order_id = $conekta_order['metadata']['reference_id'];
-        if (!$this->check_order_status($conekta_order['id'], array('expired', 'canceled'))) {
-            http_response_code(400);
-            header('Content-Type: application/json');
-            echo json_encode(['error' => 'Invalid order status', 'conekta_order_id' => $order_id]);
-            exit;
-        }
-        $order = new WC_Order($order_id);
-        $order->update_status('cancelled', 'Order expired in Conekta.');
-        header('Content-Type: application/json');
-        echo json_encode(['cancelled' => 'OK', 'conekta_order_id' => $order_id]);
-        exit;
-    }
-
-    /**
-     * @throws ApiException
-     */
-    private function handleOrderPaid($event)
-    {
-        $conekta_order = $event['data']['object'];
-        if (!$this->validate_reference_id($conekta_order)) {
-            http_response_code(400);
-            header('Content-Type: application/json');
-            echo json_encode(['error' => 'Invalid order id']);
-            exit;
-        }
-        $order_id = $conekta_order['metadata']['reference_id'];
-
-        if (!$this->check_order_status($conekta_order['id'], array('paid'))) {
-            http_response_code(400);
-            header('Content-Type: application/json');
-            echo json_encode(['error' => 'Invalid order status', 'conekta_order_id' => $order_id]);
-            exit;
-        }
-
-        $order = new WC_Order($order_id);
-        $charge = $conekta_order['charges']['data'][0];
-        $paid_at = date("Y-m-d", $charge['paid_at']);
-        update_post_meta($order->get_id(), 'conekta-paid-at', $paid_at);
-        $order->payment_complete();
-        $order->add_order_note("Payment completed in Conekta and notification of payment received");
-
-        header('Content-Type: application/json');
-        echo json_encode(['message' => 'OK']);
-        exit;
-    }
-
-    private function validate_reference_id(array $conekta_order): bool
-    {
-        return isset($conekta_order['metadata']) && array_key_exists('reference_id', $conekta_order['metadata']);
-    }
-
-    private function handleWebhookPing()
-    {
-        header('Content-Type: application/json');
-        echo json_encode(['message' => 'OK']);
-        exit;
-    }
-
-    /**
-     * @throws ApiException
-     */
-    private function check_order_status(string $conekta_order_id, array $statuses): bool
-    {
-        $conekta_order_api = $this->get_api_instance()->getorderbyid($conekta_order_id);
-
-        return in_array($conekta_order_api->getPaymentStatus(), $statuses);
-    }
 
     public function ckpg_init_form_fields()
     {
@@ -229,11 +159,17 @@ class WC_Conekta_Gateway extends WC_Conekta_Plugin
                     'data-placeholder' => __('Seleccione opciones', 'woothemes'),
                     'multiple' => 'multiple'
                 ),
+            ),
+            'webhook_url' => array(
+                'type' => 'text',
+                'title' => __('URL webhook', 'woothemes'),
+                'description' => __('URL webhook)', 'woothemes'),
+                'default' => __(get_site_url() . '/?wc-api=wc_conekta'),
+                'required' => true
             )
         );
 
     }
-
 
     protected function ckpg_mark_as_failed_payment($order)
     {
@@ -268,7 +204,8 @@ class WC_Conekta_Gateway extends WC_Conekta_Plugin
         $customer_info = ckpg_build_customer_info($data);
         $order_metadata = ckpg_build_order_metadata($data + array(
                 'plugin_conekta_version' => $this->version,
-                'woocommerce_version' => $woocommerce->version
+                'woocommerce_version' => $woocommerce->version,
+                'payment_method' => $this->GATEWAY_NAME,
             )
         );
         $rq = new OrderRequest([
@@ -304,7 +241,9 @@ class WC_Conekta_Gateway extends WC_Conekta_Plugin
             );
         } catch (Exception $e) {
             $description = $e->getMessage();
-            throw new Exception( $description );
+            wc_add_notice(__('Error: ', 'woothemes') . $description);
+            $this->ckpg_mark_as_failed_payment($order);
+            WC()->session->reload_checkout = true;
         }
 
     }

--- a/conekta_cash_block_gateway.php
+++ b/conekta_cash_block_gateway.php
@@ -56,7 +56,7 @@ class WC_Conekta_Cash_Gateway extends WC_Conekta_Plugin
             $this->enabled = false;
         }
         if ($this->enabled) {
-            $this->enabled= self::create_webhook( $this->api_key, $this->webhook_url);
+            self::create_webhook( $this->api_key, $this->webhook_url);
         }
 
     }

--- a/conekta_cash_block_gateway.php
+++ b/conekta_cash_block_gateway.php
@@ -13,6 +13,7 @@ use Conekta\ApiException;
 use \Conekta\Configuration;
 use Conekta\Model\OrderRequest;
 use Conekta\Model\CustomerShippingContacts;
+use Conekta\Model\EventTypes;
 
 class WC_Conekta_Cash_Gateway extends WC_Conekta_Plugin
 {
@@ -26,7 +27,11 @@ class WC_Conekta_Cash_Gateway extends WC_Conekta_Plugin
     public $title;
     public $description;
     public $api_key;
+    public string $webhook_url;
 
+    /**
+     * @throws ApiException
+     */
     public function __construct()
     {
         $this->id = 'conekta_cash';
@@ -37,9 +42,12 @@ class WC_Conekta_Cash_Gateway extends WC_Conekta_Plugin
         $this->title = $this->settings['title'];
         $this->description = $this->settings['description'];
         $this->api_key = $this->settings['api_key'];
+        $this->webhook_url = $this->settings['webhook_url'];
 
         add_action('woocommerce_update_options_payment_gateways_' . $this->id, array($this, 'process_admin_options'));
         add_action('woocommerce_thankyou_' . $this->id, array($this, 'ckpg_thankyou_page'));
+        add_action('woocommerce_api_wc_conekta_cash', [$this, 'check_for_webhook']);
+
         if (!$this->ckpg_validate_currency()) {
             $this->enabled = false;
         }
@@ -47,8 +55,47 @@ class WC_Conekta_Cash_Gateway extends WC_Conekta_Plugin
         if (empty($this->api_key)) {
             $this->enabled = false;
         }
+        if ($this->enabled) {
+            $this->enabled= self::create_webhook( $this->api_key, $this->webhook_url);
+        }
 
     }
+    /**
+     * @throws ApiException
+     */
+    public function check_for_webhook()
+    {
+        if (!isset($_SERVER['REQUEST_METHOD'])
+            || ('POST' !== $_SERVER['REQUEST_METHOD'])
+            || !isset($_GET['wc-api'])
+            || ('wc_conekta_cash' !== $_GET['wc-api'])
+        ) {
+            return;
+        }
+
+        $body = @file_get_contents('php://input');
+        $event = json_decode($body, true);
+
+        switch ($event['type']) {
+            case EventTypes::WEBHOOK_PING:
+                self::handleWebhookPing();
+                break;
+
+            case EventTypes::ORDER_PAID:
+                self::check_if_payment_payment_method_webhook($this->GATEWAY_NAME, $event);
+                self::handleOrderPaid($this->get_api_instance(), $event);
+                break;
+
+            case EventTypes::ORDER_EXPIRED:
+            case EventTypes::ORDER_CANCELED:
+                self::check_if_payment_payment_method_webhook($this->GATEWAY_NAME, $event);
+                self::handleOrderExpiredOrCanceled($this->get_api_instance(),$event);
+                break;
+            default:
+                break;
+        }
+    }
+
 
     public function get_api_instance(): OrdersApi
     {
@@ -108,7 +155,6 @@ class WC_Conekta_Cash_Gateway extends WC_Conekta_Plugin
                 'type' => 'password',
                 'title' => __('Conekta API key', 'woothemes'),
                 'description' => __('API Key Producción (Tokens/Llaves Privadas)', 'woothemes'),
-                'default' => __('', 'woothemes'),
                 'required' => true
             ),
             'order_expiration' => array(
@@ -121,6 +167,13 @@ class WC_Conekta_Cash_Gateway extends WC_Conekta_Plugin
                     'max' => 30,
                     'step' => 1
                 ),
+            ),
+            'webhook_url' => array(
+                'type' => 'text',
+                'title' => __('URL webhook', 'woothemes'),
+                'description' => __('URL webhook)', 'woothemes'),
+                'default' => __(get_site_url() . '/?wc-api=wc_conekta_cash'),
+                'required' => true
             )
         );
 
@@ -155,7 +208,8 @@ class WC_Conekta_Cash_Gateway extends WC_Conekta_Plugin
         $customer_info = ckpg_build_customer_info($data);
         $order_metadata = ckpg_build_order_metadata($data + array(
                 'plugin_conekta_version' => $this->version,
-                'woocommerce_version' => $woocommerce->version
+                'woocommerce_version' => $woocommerce->version,
+                'payment_method' => $this->GATEWAY_NAME,
             )
         );
         $rq = new OrderRequest([

--- a/conekta_cash_block_gateway.php
+++ b/conekta_cash_block_gateway.php
@@ -27,10 +27,10 @@ class WC_Conekta_Cash_Gateway extends WC_Conekta_Plugin
     public $title;
     public $description;
     public $api_key;
-    public string $webhook_url;
+    public $webhook_url;
 
     /**
-     * @throws ApiException
+     * @throws ApiException|Exception
      */
     public function __construct()
     {

--- a/conekta_checkout.php
+++ b/conekta_checkout.php
@@ -4,7 +4,7 @@
 Plugin Name: Conekta Payment Gateway
 Plugin URI: https://wordpress.org/plugins/conekta-payment-gateway/
 Description: Payment Gateway through Conekta.io for Woocommerce for both credit and debit cards as well as cash payments  and monthly installments for Mexican credit cards.
-Version: 5.0.1
+Version: 5.0.2
 Author: Conekta.io
 Author URI: https://www.conekta.io
 License: GNU General Public License v3.0

--- a/conekta_gateway_helper.php
+++ b/conekta_gateway_helper.php
@@ -49,6 +49,7 @@ function ckpg_build_order_metadata($data): array
         'plugin_conekta_version' => $data['plugin_conekta_version'],
         'plugin' => 'woocommerce',
         'woocommerce_version' => $data['woocommerce_version'],
+        'payment_method' => $data['payment_method'],
     );
 
     if (!empty($data['customer_message'])) {

--- a/conekta_plugin.php
+++ b/conekta_plugin.php
@@ -46,11 +46,13 @@ class WC_Conekta_Plugin extends WC_Payment_Gateway
     }
 
     /**
-     * @throws \Conekta\ApiException
      * @throws Exception
      */
-    public static function create_webhook(string $apikey, string $webhook_url): bool
+    public static function create_webhook(?string $apikey, ?string $webhook_url): bool
     {
+        if (is_null($webhook_url)){
+            return false;
+        }
         try {
             $api = new WebhooksApi(null, Configuration::getDefaultConfiguration()->setAccessToken($apikey));
             $webhooks = $api->getWebhooks("es", null,3,null, $webhook_url);

--- a/conekta_plugin.php
+++ b/conekta_plugin.php
@@ -6,9 +6,15 @@
 * Url     : https://wordpress.org/plugins/conekta-payment-gateway/
 */
 
+use Conekta\Api\WebhooksApi;
+use \Conekta\Configuration;
+use \Conekta\Model\WebhookRequest;
+use Conekta\Api\OrdersApi;
+use Conekta\ApiException;
+
 class WC_Conekta_Plugin extends WC_Payment_Gateway
 {
-	public $version  = "5.0.1";
+	public $version  = "5.0.2";
 	public $name = "WooCommerce 2";
 	public $description = "Payment Gateway through Conekta.io for Woocommerce for both credit and debit cards as well as cash payments  and monthly installments for Mexican credit cards.";
 	public $plugin_name = "Conekta Payment Gateway for Woocommerce";
@@ -37,5 +43,111 @@ class WC_Conekta_Plugin extends WC_Payment_Gateway
      */
     public static function plugin_abspath() {
         return trailingslashit( plugin_dir_path( __FILE__ ) );
+    }
+
+    /**
+     * @throws \Conekta\ApiException
+     * @throws Exception
+     */
+    public static function create_webhook(string $apikey, string $webhook_url): bool
+    {
+        try {
+            $api = new WebhooksApi(null, Configuration::getDefaultConfiguration()->setAccessToken($apikey));
+            $webhooks = $api->getWebhooks("es", null,3,null, $webhook_url);
+            if (empty($webhooks->getData())) {
+                $webhook = new WebhookRequest();
+                $webhook->setUrl($webhook_url);
+                $api->createWebhook($webhook);
+            }
+            return true;
+        }
+        catch (Exception $e) {
+            error_log($e->getMessage());
+            return false;
+        }
+    }
+    public static function handleWebhookPing()
+    {
+        header('Content-Type: application/json');
+        echo json_encode(['message' => 'OK']);
+        exit;
+    }
+    public static function check_if_payment_payment_method_webhook(string $payment_method, array $event){
+        $conekta_order = $event['data']['object'];
+        if ($conekta_order["metadata"]["payment_method"] !==  $payment_method){
+            header('Content-Type: application/json');
+            echo json_encode(['message' => 'OK', 'payment_method'=> $conekta_order["metadata"]["payment_method"]]);
+            exit;
+        }
+    }
+    /**
+     * @throws ApiException
+     */
+    public static function handleOrderPaid(OrdersApi $ordersApi, array $event)
+    {
+        $conekta_order = $event['data']['object'];
+        if (!self::validate_reference_id($conekta_order)) {
+            http_response_code(400);
+            header('Content-Type: application/json');
+            echo json_encode(['error' => 'Invalid order id']);
+            exit;
+        }
+        $order_id = $conekta_order['metadata']['reference_id'];
+
+        if (!self::check_order_status($ordersApi, $conekta_order['id'], array('paid'))) {
+            http_response_code(400);
+            header('Content-Type: application/json');
+            echo json_encode(['error' => 'Invalid order status', 'order_id' => $order_id]);
+            exit;
+        }
+
+        $order = new WC_Order($order_id);
+        $charge = $conekta_order['charges']['data'][0];
+        $paid_at = date("Y-m-d", $charge['paid_at']);
+        update_post_meta($order->get_id(), 'conekta-paid-at', $paid_at);
+        $order->payment_complete();
+        $order->add_order_note("Payment completed in Conekta and notification of payment received");
+
+        header('Content-Type: application/json');
+        echo json_encode(['message' => 'OK', 'order_id' => $order_id]);
+        exit;
+    }
+    /**
+     * @throws ApiException
+     */
+    public static function handleOrderExpiredOrCanceled(OrdersApi $ordersApi, $event)
+    {
+        $conekta_order = $event['data']['object'];
+        if (!self::validate_reference_id($conekta_order)) {
+            http_response_code(400);
+            header('Content-Type: application/json');
+            echo json_encode(['error' => 'Invalid order id']);
+            exit;
+        }
+        $order_id = $conekta_order['metadata']['reference_id'];
+        if (!self::check_order_status($ordersApi, $conekta_order['id'], array('expired', 'canceled'))) {
+            http_response_code(400);
+            header('Content-Type: application/json');
+            echo json_encode(['error' => 'Invalid order status', 'order_id' => $order_id]);
+            exit;
+        }
+        $order = new WC_Order($order_id);
+        $order->update_status('cancelled', 'Order expired/cancelled in Conekta.');
+        header('Content-Type: application/json');
+        echo json_encode(['cancelled' => 'OK', 'order_id' => $order_id]);
+        exit;
+    }
+    /**
+     * @throws ApiException
+     */
+    public static function check_order_status(OrdersApi $ordersApi, string $conekta_order_id, array $statuses): bool
+    {
+        $conekta_order_api = $ordersApi->getorderbyid($conekta_order_id);
+
+        return in_array($conekta_order_api->getPaymentStatus(), $statuses);
+    }
+    public static function validate_reference_id(array $conekta_order): bool
+    {
+        return isset($conekta_order['metadata']) && array_key_exists('reference_id', $conekta_order['metadata']);
     }
 }

--- a/readme.txt
+++ b/readme.txt
@@ -4,7 +4,7 @@ Tags: free, cash, conekta, mexico, payment gateway
 Requires at least: 6.1
 Tested up to: 6.4.2
 Requires PHP: 7.4
-Stable tag: 5.0.1
+Stable tag: 5.0.2
 License: GPLv2 or later
 License URI: http://www.gnu.org/licenses/gpl-2.0.html
 
@@ -47,6 +47,9 @@ By following these steps, you'll successfully install and configure the Conekta 
 `/assets/screenshot-2.png`
 
 == Changelog ==
+= 5.0.2 =
+* Fix webhook for paid orders
+* Automatically config webhook in the plugin settings
 = 5.0.1 =
 * Fix unauthorized Client
 = 5.0.0 =


### PR DESCRIPTION
task https://conekta.atlassian.net/browse/CRD-183


Después de la version 5.0.1 se encontró un bug. que no transiciona los estados de las ordenes a paid o expired

Ahora los 3 métodos de pago necesitan cada uno su propio webhook.

Se disponibiliza el self-created webhook desde la config de woocommerce.