### PR TITLE
chore: release version 5.4.14 with webhook fixes and enhancements

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,3 +1,13 @@
+5.4.14, 2026-04-10
+-------------------------------------
+- Fix: Webhook order.paid/order.expired now uses wc_get_order() with fallback lookup by conekta-order-id meta, fixing HPOS compatibility and 3DS temp order mismatch
+- Fix: validate_reference_id now rejects empty, non-numeric, zero, and negative values
+- Enhancement: Optimized WordPress.org SVN deployment — exclude dev files, add --delete for clean sync, use --no-dev for composer, and shallow SVN checkout to skip historical tags
+- Enhancement: Reduced CI log noise with quiet flags on svn, rsync, and apt-get commands
+
+## [5.4.13]() - 2026-04-10
+- Enhancement: Optimize WordPress.org SVN deployment — exclude dev files, add `--delete` for clean sync, use `--no-dev` for composer, and shallow SVN checkout to skip historical tags
+- Enhancement: Reduce CI log noise with quiet flags on svn, rsync, and apt-get commands
 5.4.12, 2026-04-10
 -------------------------------------
 - Feature: Full support for dynamic pricing plugins (Advanced Dynamic Pricing and Discount Rules)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,9 @@
+## [5.4.14]() - 2026-04-10
+- Fix: Webhook `order.paid`/`order.expired` now uses `wc_get_order()` with fallback lookup by `conekta-order-id` meta, fixing HPOS compatibility and 3DS temp order mismatch
+- Fix: `validate_reference_id` now rejects empty, non-numeric, zero, and negative values
+- Enhancement: Optimized WordPress.org SVN deployment — exclude dev files, add `--delete` for clean sync, use `--no-dev` for composer, and shallow SVN checkout to skip historical tags
+- Enhancement: Reduced CI log noise with quiet flags on svn, rsync, and apt-get commands
+
 ## [5.4.13]() - 2026-04-10
 - Enhancement: Optimize WordPress.org SVN deployment — exclude dev files, add `--delete` for clean sync, use `--no-dev` for composer, and shallow SVN checkout to skip historical tags
 - Enhancement: Reduce CI log noise with quiet flags on svn, rsync, and apt-get commands

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 <div align="center">
 
-# Conekta Woocommerce v.5.4.13
+# Conekta Woocommerce v.5.4.14
 [![Made with PHP](https://img.shields.io/badge/made%20with-php-red.svg?style=for-the-badge&colorA=ED4040&colorB=C12C2D)](http://php.net) 
 [![By Conekta](https://img.shields.io/badge/by-conekta-red.svg?style=for-the-badge&colorA=ee6130&colorB=00a4ac)](https://conekta.com)
 </div>

--- a/conekta_checkout.php
+++ b/conekta_checkout.php
@@ -4,7 +4,7 @@
 Plugin Name: Conekta Payment Gateway
 Plugin URI: https://wordpress.org/plugins/conekta-payment-gateway/
 Description: Payment Gateway through Conekta.io for Woocommerce for both credit and debit cards as well as cash payments  and monthly installments for Mexican credit cards.
-Version: 5.4.13
+Version: 5.4.14
 Requires at least: 6.6.2
 Requires PHP: 7.4
 Author: Conekta.io

--- a/conekta_plugin.php
+++ b/conekta_plugin.php
@@ -22,7 +22,7 @@ require_once(__DIR__ . '/conekta-rest-api.php');
 
 class WC_Conekta_Plugin extends WC_Payment_Gateway
 {
-	public $version  = "5.4.13";
+	public $version  = "5.4.14";
 	public $name = "WooCommerce 2";
 	public $description = "Payment Gateway via Conekta.io for WooCommerce: accepts credit, debit, cash, and monthly installments for Mexican credit cards.";
 	public $plugin_name = "Conekta Payment Gateway for Woocommerce";
@@ -104,24 +104,30 @@ class WC_Conekta_Plugin extends WC_Payment_Gateway
             echo json_encode(['error' => 'Invalid order id']);
             exit;
         }
-        $order_id = $conekta_order['metadata']['reference_id'];
 
         if (!self::check_order_status($ordersApi, $conekta_order['id'], array('paid'))) {
             http_response_code(400);
             header('Content-Type: application/json');
-            echo json_encode(['error' => 'Invalid order status', 'order_id' => $order_id]);
+            echo json_encode(['error' => 'Invalid order status']);
             exit;
         }
 
-        $order = new WC_Order($order_id);
+        $order = self::find_order_for_webhook($conekta_order);
+        if (!$order) {
+            http_response_code(404);
+            header('Content-Type: application/json');
+            echo json_encode(['error' => 'Order not found', 'reference_id' => $conekta_order['metadata']['reference_id'], 'conekta_id' => $conekta_order['id']]);
+            exit;
+        }
+
         $charge = $conekta_order['charges']['data'][0];
         $paid_at = date("Y-m-d", $charge['paid_at']);
-        update_post_meta($order->get_id(), 'conekta-paid-at', $paid_at);
+        self::update_conekta_order_meta($order, $paid_at, 'conekta-paid-at');
         $order->payment_complete();
         $order->add_order_note("Payment completed in Conekta and notification of payment received");
 
         header('Content-Type: application/json');
-        echo json_encode(['message' => 'OK', 'order_id' => $order_id]);
+        echo json_encode(['message' => 'OK', 'order_id' => $order->get_id()]);
         exit;
     }
     
@@ -137,17 +143,25 @@ class WC_Conekta_Plugin extends WC_Payment_Gateway
             echo json_encode(['error' => 'Invalid order id']);
             exit;
         }
-        $order_id = $conekta_order['metadata']['reference_id'];
+
         if (!self::check_order_status($ordersApi, $conekta_order['id'], array('expired', 'canceled'))) {
             http_response_code(400);
             header('Content-Type: application/json');
-            echo json_encode(['error' => 'Invalid order status', 'order_id' => $order_id]);
+            echo json_encode(['error' => 'Invalid order status']);
             exit;
         }
-        $order = new WC_Order($order_id);
+
+        $order = self::find_order_for_webhook($conekta_order);
+        if (!$order) {
+            http_response_code(404);
+            header('Content-Type: application/json');
+            echo json_encode(['error' => 'Order not found', 'reference_id' => $conekta_order['metadata']['reference_id'], 'conekta_id' => $conekta_order['id']]);
+            exit;
+        }
+
         $order->update_status('cancelled', 'Order expired/cancelled in Conekta.');
         header('Content-Type: application/json');
-        echo json_encode(['cancelled' => 'OK', 'order_id' => $order_id]);
+        echo json_encode(['cancelled' => 'OK', 'order_id' => $order->get_id()]);
         exit;
     }
     
@@ -163,7 +177,45 @@ class WC_Conekta_Plugin extends WC_Payment_Gateway
     
     public static function validate_reference_id(array $conekta_order): bool
     {
-        return isset($conekta_order['metadata']) && array_key_exists('reference_id', $conekta_order['metadata']);
+        return isset($conekta_order['metadata'])
+            && array_key_exists('reference_id', $conekta_order['metadata'])
+            && is_numeric($conekta_order['metadata']['reference_id'])
+            && (int) $conekta_order['metadata']['reference_id'] > 0;
+    }
+
+    /**
+     * Finds the WooCommerce order for a Conekta webhook event.
+     * First tries metadata.reference_id, then falls back to searching
+     * by conekta-order-id meta (covers 3DS temp order scenario).
+     *
+     * @return WC_Order|false
+     */
+    public static function find_order_for_webhook(array $conekta_order)
+    {
+        $order_id = $conekta_order['metadata']['reference_id'] ?? null;
+
+        if ($order_id) {
+            $order = wc_get_order($order_id);
+            if ($order) {
+                return $order;
+            }
+        }
+
+        // Fallback: temp order was deleted after 3DS transfer,
+        // find the real order by conekta-order-id meta.
+        $conekta_id = $conekta_order['id'] ?? null;
+        if ($conekta_id) {
+            $orders = wc_get_orders([
+                'meta_key'   => 'conekta-order-id',
+                'meta_value' => $conekta_id,
+                'limit'      => 1,
+            ]);
+            if (!empty($orders)) {
+                return $orders[0];
+            }
+        }
+
+        return false;
     }
 
     /**

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "conekta-payment-gateway",
-  "version": "5.4.13",
+  "version": "5.4.14",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "conekta-payment-gateway",
-      "version": "5.4.13",
+      "version": "5.4.14",
       "license": "ISC",
       "dependencies": {
         "@woocommerce/settings": "^1.0.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "conekta-payment-gateway",
-  "version": "5.4.13",
+  "version": "5.4.14",
   "description": "<div align=\"center\">",
   "main": "index.js",
   "directories": {

--- a/readme.txt
+++ b/readme.txt
@@ -4,7 +4,7 @@ Tags: free, cash, conekta, mexico, payment gateway
 Requires at least: 6.1
 Tested up to: 6.9.4
 Requires PHP: 7.4
-Stable tag: 5.4.13
+Stable tag: 5.4.14
 License: GPLv2 or later
 License URI: http://www.gnu.org/licenses/gpl-2.0.html
 

--- a/resources/js/frontend/classic-checkout.js
+++ b/resources/js/frontend/classic-checkout.js
@@ -614,7 +614,7 @@ document.addEventListener("DOMContentLoaded", () => {
     }
   });
 
-  document.body.addEventListener("updated_checkout", () => {
+  jQuery(document.body).on("updated_checkout", () => {
     // Sync conekta_settings with the latest cart data from the PHP fragment
     // (covers dynamic pricing, coupons, and any cart change after page load)
     const cartDataEl = document.getElementById('conekta-cart-data');

--- a/resources/js/frontend/classic-checkout.js
+++ b/resources/js/frontend/classic-checkout.js
@@ -41,20 +41,20 @@ const utils = {
   },
   setLoading: (isLoading) => {
     const form = document.querySelector(FORM_SELECTOR);
-    if (!form || typeof jQuery === "undefined") return;
-
-    const $form = jQuery(form);
+    if (!form) return;
 
     if (isLoading) {
-      $form.block({
-        message: null,
-        overlayCSS: {
-          background: "#fff",
-        },
-      });
+      if (!form.querySelector('.conekta-loading-overlay')) {
+        const overlay = document.createElement('div');
+        overlay.className = 'conekta-loading-overlay';
+        overlay.style.cssText = 'position:absolute;top:0;left:0;right:0;bottom:0;background:rgba(255,255,255,0.6);z-index:1000;';
+        form.style.position = 'relative';
+        form.appendChild(overlay);
+      }
       form.classList.add('three-ds-process');
     } else {
-      $form.unblock();
+      const overlay = form.querySelector('.conekta-loading-overlay');
+      if (overlay) overlay.remove();
       form.classList.remove('three-ds-process');
     }
   },
@@ -614,7 +614,7 @@ document.addEventListener("DOMContentLoaded", () => {
     }
   });
 
-  jQuery(document.body).on("updated_checkout", () => {
+  const onUpdatedCheckout = () => {
     // Sync conekta_settings with the latest cart data from the PHP fragment
     // (covers dynamic pricing, coupons, and any cart change after page load)
     const cartDataEl = document.getElementById('conekta-cart-data');
@@ -667,5 +667,22 @@ document.addEventListener("DOMContentLoaded", () => {
     }
     
     setTimeout(conektaInitializer.initialize, POLLING_INTERVAL);
-  });
+  };
+
+  // Detect WooCommerce checkout refreshes: WC replaces DOM fragments
+  // after AJAX; #conekta-cart-data lives outside the form, so we
+  // observe document.body and fire onUpdatedCheckout when it's added.
+  new MutationObserver((mutations) => {
+    for (const m of mutations) {
+      for (const node of m.addedNodes) {
+        if (node.id === 'conekta-cart-data' ||
+            (node.querySelector && node.querySelector('#conekta-cart-data'))) {
+          onUpdatedCheckout();
+          return;
+        }
+      }
+    }
+  }).observe(document.body, { childList: true, subtree: true });
+  // Also support native event dispatch (used by tests)
+  document.body.addEventListener("updated_checkout", onUpdatedCheckout);
 });

--- a/tests/WC_Conekta_Gateway_Test.php
+++ b/tests/WC_Conekta_Gateway_Test.php
@@ -37,9 +37,10 @@ class WC_Conekta_Gateway_Test extends TestCase
 
     protected function tearDown(): void
     {
-        global $test_product_registry;
+        global $test_product_registry, $test_order_registry;
         WC()->cart = null;
         $test_product_registry = [];
+        $test_order_registry = null;
         parent::tearDown();
     }
 
@@ -134,6 +135,170 @@ class WC_Conekta_Gateway_Test extends TestCase
     {
         $result = WC_Conekta_Plugin::validate_reference_id([]);
         $this->assertFalse($result);
+    }
+
+    public function test_validate_reference_id_with_empty_string()
+    {
+        $result = WC_Conekta_Plugin::validate_reference_id([
+            'metadata' => ['reference_id' => ''],
+        ]);
+        $this->assertFalse($result, 'Empty string reference_id should be invalid');
+    }
+
+    public function test_validate_reference_id_with_zero()
+    {
+        $result = WC_Conekta_Plugin::validate_reference_id([
+            'metadata' => ['reference_id' => '0'],
+        ]);
+        $this->assertFalse($result, 'Zero reference_id should be invalid');
+    }
+
+    public function test_validate_reference_id_with_non_numeric()
+    {
+        $result = WC_Conekta_Plugin::validate_reference_id([
+            'metadata' => ['reference_id' => 'abc'],
+        ]);
+        $this->assertFalse($result, 'Non-numeric reference_id should be invalid');
+    }
+
+    public function test_validate_reference_id_with_negative()
+    {
+        $result = WC_Conekta_Plugin::validate_reference_id([
+            'metadata' => ['reference_id' => '-1'],
+        ]);
+        $this->assertFalse($result, 'Negative reference_id should be invalid');
+    }
+
+    public function test_validate_reference_id_with_integer()
+    {
+        $result = WC_Conekta_Plugin::validate_reference_id([
+            'metadata' => ['reference_id' => 1285],
+        ]);
+        $this->assertTrue($result, 'Integer reference_id should be valid');
+    }
+
+    public function test_validate_reference_id_with_null()
+    {
+        $result = WC_Conekta_Plugin::validate_reference_id([
+            'metadata' => ['reference_id' => null],
+        ]);
+        $this->assertFalse($result, 'Null reference_id should be invalid');
+    }
+
+    // -------------------------------------------------------
+    // Webhook order lookup — find_order_for_webhook()
+    // -------------------------------------------------------
+
+    /**
+     * When reference_id points to a valid order, return it directly.
+     */
+    public function test_find_order_for_webhook_by_reference_id()
+    {
+        global $test_order_registry;
+        $order = new WC_Order(1308);
+        $test_order_registry[1308] = $order;
+
+        $conekta_order = [
+            'id' => 'ord_abc123',
+            'metadata' => ['reference_id' => '1308'],
+        ];
+
+        $found = WC_Conekta_Plugin::find_order_for_webhook($conekta_order);
+        $this->assertNotFalse($found);
+        $this->assertEquals(1308, $found->get_id());
+    }
+
+    /**
+     * When reference_id points to a deleted temp order but a real order
+     * holds the conekta-order-id meta, the fallback should find it.
+     */
+    public function test_find_order_for_webhook_fallback_by_conekta_meta()
+    {
+        global $test_order_registry;
+
+        // Real order 1308 has the conekta-order-id meta
+        $real_order = new WC_Order(1308);
+        $real_order->update_meta_data('conekta-order-id', 'ord_abc123');
+        $test_order_registry[1308] = $real_order;
+
+        // Temp order 1309 was deleted — NOT in registry
+
+        $conekta_order = [
+            'id' => 'ord_abc123',
+            'metadata' => ['reference_id' => '1309'],
+        ];
+
+        $found = WC_Conekta_Plugin::find_order_for_webhook($conekta_order);
+        $this->assertNotFalse($found, 'Should find order by conekta-order-id meta when reference_id order is deleted');
+        $this->assertEquals(1308, $found->get_id());
+    }
+
+    /**
+     * When neither reference_id nor conekta-order-id meta match, return false.
+     */
+    public function test_find_order_for_webhook_returns_false_when_not_found()
+    {
+        global $test_order_registry;
+        // Registry is empty — no orders at all
+        $test_order_registry = [];
+
+        $conekta_order = [
+            'id' => 'ord_ghost',
+            'metadata' => ['reference_id' => '9999'],
+        ];
+
+        $found = WC_Conekta_Plugin::find_order_for_webhook($conekta_order);
+        $this->assertFalse($found);
+    }
+
+    /**
+     * When reference_id arrives as integer (observed in production),
+     * lookup should still work.
+     */
+    public function test_find_order_for_webhook_with_integer_reference_id()
+    {
+        global $test_order_registry;
+        $order = new WC_Order(1285);
+        $test_order_registry[1285] = $order;
+
+        $conekta_order = [
+            'id' => 'ord_int123',
+            'metadata' => ['reference_id' => 1285],
+        ];
+
+        $found = WC_Conekta_Plugin::find_order_for_webhook($conekta_order);
+        $this->assertNotFalse($found);
+        $this->assertEquals(1285, $found->get_id());
+    }
+
+    // -------------------------------------------------------
+    // update_conekta_order_meta — writes to WC_Order meta
+    // -------------------------------------------------------
+
+    public function test_update_conekta_order_meta_stores_value_in_order_meta()
+    {
+        $order = new WC_Order(500);
+        WC_Conekta_Plugin::update_conekta_order_meta($order, 'ord_abc123', 'conekta-order-id');
+
+        $this->assertEquals('ord_abc123', $order->get_meta('conekta-order-id'));
+    }
+
+    public function test_update_conekta_order_meta_paid_at()
+    {
+        $order = new WC_Order(501);
+        $paid_at = date("Y-m-d", 1712700000);
+        WC_Conekta_Plugin::update_conekta_order_meta($order, $paid_at, 'conekta-paid-at');
+
+        $this->assertEquals($paid_at, $order->get_meta('conekta-paid-at'));
+    }
+
+    public function test_update_conekta_order_meta_overwrites_previous_value()
+    {
+        $order = new WC_Order(502);
+        WC_Conekta_Plugin::update_conekta_order_meta($order, 'old_value', 'conekta-order-id');
+        WC_Conekta_Plugin::update_conekta_order_meta($order, 'new_value', 'conekta-order-id');
+
+        $this->assertEquals('new_value', $order->get_meta('conekta-order-id'));
     }
 
     // -------------------------------------------------------

--- a/tests/bootstrap.php
+++ b/tests/bootstrap.php
@@ -49,8 +49,39 @@ if (!function_exists('get_user_meta')) {
 if (!function_exists('wc_add_notice')) {
     function wc_add_notice($message, $type = 'notice') {}
 }
+// Global order registry — allows tests to pre-register orders so that
+// wc_get_order() can return false for deleted orders and wc_get_orders()
+// can search by meta.
+global $test_order_registry;
+$test_order_registry = null; // null = not active (legacy), array = active registry
+
 if (!function_exists('wc_get_order')) {
-    function wc_get_order($order_id) { return new WC_Order($order_id); }
+    function wc_get_order($order_id) {
+        global $test_order_registry;
+        if (is_array($test_order_registry)) {
+            return $test_order_registry[$order_id] ?? false;
+        }
+        return new WC_Order($order_id);
+    }
+}
+if (!function_exists('wc_get_orders')) {
+    function wc_get_orders($args = []) {
+        global $test_order_registry;
+        $results = [];
+        $meta_key = $args['meta_key'] ?? null;
+        $meta_value = $args['meta_value'] ?? null;
+        $limit = $args['limit'] ?? -1;
+
+        foreach ($test_order_registry as $order) {
+            if ($meta_key && $meta_value && $order->get_meta($meta_key) === $meta_value) {
+                $results[] = $order;
+            }
+            if ($limit > 0 && count($results) >= $limit) {
+                break;
+            }
+        }
+        return $results;
+    }
 }
 if (!function_exists('wpautop')) {
     function wpautop($text) { return $text; }

--- a/tests/e2e/checkout-helpers.js
+++ b/tests/e2e/checkout-helpers.js
@@ -2,8 +2,13 @@
  * Shared helpers for E2E checkout tests (classic + blocks).
  */
 const { chromium } = require('playwright');
-const { mkdirSync } = require('fs');
+const { mkdirSync, readFileSync } = require('fs');
+const { join } = require('path');
 const config = require('./e2e.config');
+
+const EXPECTED_VERSION = JSON.parse(
+  readFileSync(join(__dirname, '..', '..', 'package.json'), 'utf8')
+).version;
 
 mkdirSync(config.video.dir, { recursive: true });
 mkdirSync(config.screenshot.dir, { recursive: true });
@@ -96,13 +101,25 @@ async function setup() {
 
   console.log('Setup: Login...');
   await page.goto(`${STORE_URL}/wp-login.php`);
+  await page.waitForSelector('#user_login', { state: 'visible' });
   await page.fill('#user_login', WP_USER);
   await page.fill('#user_pass', WP_PASS);
   await page.click('#wp-submit');
   await page.waitForLoadState('networkidle');
 
   await page.goto(`${STORE_URL}/wp-admin/`);
-  await page.waitForLoadState('networkidle');
+  await page.waitForLoadState('domcontentloaded');
+
+  // Version gate: ensure the staging store runs the same plugin version as this branch
+  const sysStatus = await wcApi('GET', 'wc/v3/system_status');
+  const conektaPlugin = sysStatus?.active_plugins?.find(p => p.name === 'Conekta Payment Gateway');
+  const storeVersion = conektaPlugin?.version;
+  if (storeVersion !== EXPECTED_VERSION) {
+    throw new Error(
+      `Plugin version mismatch: store has ${storeVersion || 'NOT FOUND'}, expected ${EXPECTED_VERSION}. Deploy the plugin before running E2E tests.`
+    );
+  }
+  console.log(`Setup: plugin version OK (${storeVersion})`);
 
   // Cleanup orphaned e2e resources from previous crashed runs
   const staleProducts = await wcApi('GET', 'wc/v3/products?search=E2E+Discount+Test&per_page=50');
@@ -138,27 +155,53 @@ async function setup() {
 
   await page.goto(`${STORE_URL}/?add-to-cart=${productId}`);
   await page.waitForLoadState('networkidle');
+}
 
-  await page.goto(`${STORE_URL}/cart/`);
-  await page.waitForLoadState('networkidle');
-  const couponApplied = await page.evaluate(async ({ code }) => {
-    // Try multiple nonce sources
+/**
+ * Apply a coupon on the classic checkout page using the native WC coupon form.
+ * This avoids Store API session-sync race conditions because the coupon is
+ * applied in the same PHP session context as the checkout page itself.
+ */
+async function applyCheckoutCoupon(code) {
+  // Show the coupon form (hidden by default on classic checkout)
+  const toggle = await page.$('.woocommerce-form-coupon-toggle .showcoupon');
+  if (toggle) await toggle.click();
+
+  await page.waitForSelector('.checkout_coupon #coupon_code', { state: 'visible', timeout: 5000 });
+  await page.fill('.checkout_coupon #coupon_code', code);
+
+  // Set up listeners BEFORE clicking so we catch both AJAX responses:
+  // 1) apply_coupon — applies the coupon to the cart
+  // 2) update_order_review — WC rebuilds fragments (includes discount_lines)
+  const applyDone = page.waitForResponse(
+    r => r.url().includes('wc-ajax=apply_coupon'), { timeout: 10000 }
+  );
+  const updateDone = page.waitForResponse(
+    r => r.url().includes('wc-ajax=update_order_review'), { timeout: 15000 }
+  );
+
+  await page.click('.checkout_coupon button[name="apply_coupon"]');
+  await applyDone;
+  await updateDone;
+  await page.waitForTimeout(500); // Let the updated_checkout JS event propagate
+}
+
+/**
+ * Apply a coupon on the blocks checkout page via the Store API.
+ * No race condition here because blocks reads from the Store API directly.
+ */
+async function applyBlocksCoupon(code) {
+  await page.evaluate(async ({ code }) => {
     const cartRes = await fetch('/wp-json/wc/store/v1/cart', { credentials: 'same-origin' });
-    const nonce = cartRes.headers.get('Nonce')
-      || cartRes.headers.get('X-WC-Store-API-Nonce')
-      || (typeof wcBlocksMiddlewareConfig !== 'undefined' ? wcBlocksMiddlewareConfig.storeApiNonce : '')
-      || '';
-
-    const res = await fetch('/wp-json/wc/store/v1/cart/apply-coupon', {
+    const nonce = cartRes.headers.get('Nonce') || cartRes.headers.get('X-WC-Store-API-Nonce') || '';
+    await fetch('/wp-json/wc/store/v1/cart/apply-coupon', {
       method: 'POST',
       headers: { 'Content-Type': 'application/json', 'Nonce': nonce },
       credentials: 'same-origin',
       body: JSON.stringify({ code }),
     });
-    const data = await res.json();
-    return { status: res.status, coupons: data.coupons?.length || 0 };
-  }, { code: couponCode });
-  console.log(`Setup: Coupon apply status=${couponApplied.status} coupons=${couponApplied.coupons}`);
+  }, { code });
+  await page.waitForTimeout(2000); // Let the blocks UI update
 }
 
 async function teardown() {
@@ -259,5 +302,6 @@ module.exports = {
   STORE_URL, CONEKTA_API_KEY, REGULAR_PRICE, DISCOUNT_AMOUNT, COUPON_AMOUNT,
   TEST_CARD, BILLING,
   assert, getPage, getCounters, wcApi, setCheckoutType,
+  applyCheckoutCoupon, applyBlocksCoupon,
   setup, teardown, testOrderStatus, test3dsFlow, run,
 };

--- a/tests/e2e/discount-3ds-blocks.spec.js
+++ b/tests/e2e/discount-3ds-blocks.spec.js
@@ -11,7 +11,10 @@ h.run('Blocks Checkout — Discount + 3DS', async ({ page, assert, config, coupo
   await page.goto(`${STORE_URL}/checkout/`);
   await page.waitForLoadState('networkidle');
   await page.waitForSelector('.wc-block-checkout', { timeout: config.timeouts.selector });
-  await page.waitForTimeout(3000);
+  await page.waitForTimeout(2000);
+
+  // Apply coupon on the blocks checkout page
+  await h.applyBlocksCoupon(couponCode);
 
   // --- Order summary shows product + discount ---
   console.log('--- Order summary ---');

--- a/tests/e2e/discount-3ds-classic.spec.js
+++ b/tests/e2e/discount-3ds-classic.spec.js
@@ -13,7 +13,7 @@ h.run('Classic Checkout — Discount + 3DS', async ({ page, assert, config, coup
   await page.waitForSelector('form.checkout', { timeout: config.timeouts.selector });
   await page.waitForTimeout(2000);
 
-  // --- conekta_settings ---
+  // --- conekta_settings (before coupon) ---
   console.log('--- conekta_settings ---');
   const settings = await page.evaluate(() => window.conekta_settings);
   assert(settings !== undefined, 'conekta_settings exists');
@@ -21,29 +21,35 @@ h.run('Classic Checkout — Discount + 3DS', async ({ page, assert, config, coup
   assert(settings.three_ds_enabled == 1 || settings.three_ds_enabled === 'yes', `3DS enabled = ${settings.three_ds_enabled}`);
   assert(settings.cart_items.length > 0, `cart_items count = ${settings.cart_items.length}`);
 
-  // --- discount_lines ---
+  // --- Apply coupon on checkout page (same session, no race condition) ---
+  console.log('\n--- Apply coupon ---');
+  await h.applyCheckoutCoupon(couponCode);
+
+  // --- discount_lines (read from the PHP fragment — the authoritative source) ---
   console.log('\n--- discount_lines ---');
-  const dl = settings.discount_lines;
-  assert(dl.length >= 1, `discount_lines count = ${dl.length}`);
+  const fragment = await page.$('#conekta-cart-data');
+  assert(fragment !== null, '#conekta-cart-data exists');
+  const fragData = JSON.parse(await fragment.evaluate(el => el.textContent));
+  const dl = fragData.discount_lines;
+  assert(dl.length >= 2, `discount_lines count = ${dl.length}`);
   assert(dl.find(d => d.code === 'dynamic_pricing')?.type === 'campaign', `dynamic_pricing type = campaign`);
 
   const couponEntry = dl.find(d => d.code === couponCode);
   assert(couponEntry?.type === 'coupon', `coupon type = ${couponEntry?.type || 'NOT APPLIED'}`);
+  assert(couponEntry?.amount > 0, `coupon amount = ${couponEntry?.amount}`);
 
   // --- Double-counting guard ---
   console.log('\n--- Guard ---');
   assert(dl.filter(d => d.code === 'dynamic_pricing').length === 1, 'no duplicate dynamic_pricing');
-  assert(dl.filter(d => d.code === couponCode).length <= 1, `coupon entries = ${dl.filter(d => d.code === couponCode).length}`);
+  assert(dl.filter(d => d.code === couponCode).length === 1, `coupon entries = ${dl.filter(d => d.code === couponCode).length}`);
 
-  // --- Fragment element ---
-  console.log('\n--- Fragment ---');
-  const fragment = await page.$('#conekta-cart-data');
-  assert(fragment !== null, '#conekta-cart-data exists');
-  const fragData = JSON.parse(await fragment.evaluate(el => el.textContent));
-  assert(fragData.discount_lines.filter(d => d.code === 'dynamic_pricing').length === 1, 'fragment: 1 dynamic_pricing');
+  // --- JS sync: conekta_settings should match fragment after updated_checkout ---
+  console.log('\n--- JS sync ---');
+  const synced = await page.evaluate(() => window.conekta_settings);
+  assert(synced.discount_lines.length === dl.length, `conekta_settings synced = ${synced.discount_lines.length} discount_lines`);
 
   // --- Billing form ---
-  console.log('\n--- Billing + sync ---');
+  console.log('\n--- Billing ---');
   await page.fill('#billing_first_name', BILLING.first_name);
   await page.fill('#billing_last_name', BILLING.last_name);
   await page.fill('#billing_address_1', BILLING.address_1);
@@ -53,9 +59,6 @@ h.run('Classic Checkout — Discount + 3DS', async ({ page, assert, config, coup
   await page.fill('#billing_phone', BILLING.phone);
   await page.fill('#billing_email', BILLING.email);
   await page.waitForTimeout(4000);
-
-  const updated = await page.evaluate(() => window.conekta_settings);
-  assert(updated.discount_lines.length >= 1, `post-sync discount_lines = ${updated.discount_lines.length}`);
 
   // --- Tokenizer + pay ---
   console.log('\n--- Card + Place Order ---');

--- a/tests/js/classic-checkout.test.js
+++ b/tests/js/classic-checkout.test.js
@@ -1,3 +1,6 @@
+/**
+ * @jest-environment jsdom
+ */
 const fs = require('fs');
 const path = require('path');
 


### PR DESCRIPTION
- Fix: Webhook `order.paid`/`order.expired` now uses `wc_get_order()` with fallback lookup by `conekta-order-id` meta, fixing HPOS compatibility and 3DS temp order mismatch
- Fix: `validate_reference_id` now rejects empty, non-numeric, zero, and negative values
- Enhancement: Optimized WordPress.org SVN deployment — exclude dev files, add `--delete` for clean sync, use `--no-dev` for composer, and shallow SVN checkout to skip historical tags
- Enhancement: Reduced CI log noise with quiet flags on svn, rsync, and apt-get commands