### PR TITLE
BE-839: Fix IVA reporting for items and shipping

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,3 +1,7 @@
+5.4.15, 2026-05-25
+-------------------------------------
+- Fix: ckpg_build_tax_lines now reads tax_total/shipping_tax_total from WC_Order_Item_Tax objects (WooCommerce 3.0+), so IVA over items and shipping is reported correctly to Conekta instead of being collapsed into a "Round Adjustment" line
+
 5.4.14, 2026-04-10
 -------------------------------------
 - Fix: Webhook order.paid/order.expired now uses wc_get_order() with fallback lookup by conekta-order-id meta, fixing HPOS compatibility and 3DS temp order mismatch

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,6 @@
+## [5.4.15]() - 2026-05-25
+- Fix: `ckpg_build_tax_lines` now reads `tax_total`/`shipping_tax_total` from `WC_Order_Item_Tax` objects (WooCommerce 3.0+), so IVA over items and shipping is reported correctly to Conekta instead of being collapsed into a "Round Adjustment" line
+
 ## [5.4.14]() - 2026-04-10
 - Fix: Webhook `order.paid`/`order.expired` now uses `wc_get_order()` with fallback lookup by `conekta-order-id` meta, fixing HPOS compatibility and 3DS temp order mismatch
 - Fix: `validate_reference_id` now rejects empty, non-numeric, zero, and negative values

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 <div align="center">
 
-# Conekta Woocommerce v.5.4.14
+# Conekta Woocommerce v.5.4.15
 [![Made with PHP](https://img.shields.io/badge/made%20with-php-red.svg?style=for-the-badge&colorA=ED4040&colorB=C12C2D)](http://php.net) 
 [![By Conekta](https://img.shields.io/badge/by-conekta-red.svg?style=for-the-badge&colorA=ee6130&colorB=00a4ac)](https://conekta.com)
 </div>

--- a/conekta_checkout.php
+++ b/conekta_checkout.php
@@ -4,7 +4,7 @@
 Plugin Name: Conekta Payment Gateway
 Plugin URI: https://wordpress.org/plugins/conekta-payment-gateway/
 Description: Payment Gateway through Conekta.io for Woocommerce for both credit and debit cards as well as cash payments  and monthly installments for Mexican credit cards.
-Version: 5.4.14
+Version: 5.4.15
 Requires at least: 6.6.2
 Requires PHP: 7.4
 Author: Conekta.io

--- a/conekta_gateway_helper.php
+++ b/conekta_gateway_helper.php
@@ -126,30 +126,24 @@ function ckpg_build_tax_lines($taxes): array
     $tax_lines = array();
 
     foreach ($taxes as $tax) {
+        // WooCommerce >= 3.0 returns WC_Order_Item_Tax objects whose ArrayAccess
+        // keys are `tax_total` / `shipping_tax_total`. Older code paths (and the
+        // legacy test fixtures) used `tax_amount` / `shipping_tax_amount`.
+        $items_tax    = (float) ($tax['tax_total'] ?? $tax['tax_amount'] ?? 0);
+        $shipping_tax = (float) ($tax['shipping_tax_total'] ?? $tax['shipping_tax_amount'] ?? 0);
+        $label        = esc_html((string) ($tax['label'] ?? ''));
 
+        if ($items_tax != 0) {
+            $tax_lines[] = array(
+                'description' => $label,
+                'amount'      => amount_validation($items_tax),
+            );
+        }
 
-        $tax_amount = floatval($tax['tax_amount']) * 1000;
-        $tax_name    = (string)$tax['label'];
-        $tax_name    = esc_html($tax_name);
-
-
-        $tax_lines  = array_merge($tax_lines, array(
-            array(
-                'description' => $tax_name,
-                'amount'      => intval(round(floatval($tax_amount) / 10), 2)
-            )
-        ));
-
-        if (isset($tax['shipping_tax_amount'])) {
-            $tax_amount = floatval($tax['shipping_tax_amount']) * 1000;
-            $amount     = intval(round(floatval($tax_amount) / 10), 2);
-            $tax_lines  = array_merge(
-                $tax_lines, array(
-                    array(
-                        'description' => 'Shipping tax',
-                        'amount'      => $amount
-                    )
-                )
+        if ($shipping_tax != 0) {
+            $tax_lines[] = array(
+                'description' => 'Shipping tax',
+                'amount'      => amount_validation($shipping_tax),
             );
         }
     }

--- a/conekta_plugin.php
+++ b/conekta_plugin.php
@@ -22,7 +22,7 @@ require_once(__DIR__ . '/conekta-rest-api.php');
 
 class WC_Conekta_Plugin extends WC_Payment_Gateway
 {
-	public $version  = "5.4.14";
+	public $version  = "5.4.15";
 	public $name = "WooCommerce 2";
 	public $description = "Payment Gateway via Conekta.io for WooCommerce: accepts credit, debit, cash, and monthly installments for Mexican credit cards.";
 	public $plugin_name = "Conekta Payment Gateway for Woocommerce";

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "conekta-payment-gateway",
-  "version": "5.4.14",
+  "version": "5.4.15",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "conekta-payment-gateway",
-      "version": "5.4.14",
+      "version": "5.4.15",
       "license": "ISC",
       "dependencies": {
         "@woocommerce/settings": "^1.0.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "conekta-payment-gateway",
-  "version": "5.4.14",
+  "version": "5.4.15",
   "description": "<div align=\"center\">",
   "main": "index.js",
   "directories": {

--- a/readme.txt
+++ b/readme.txt
@@ -4,7 +4,7 @@ Tags: free, cash, conekta, mexico, payment gateway
 Requires at least: 6.1
 Tested up to: 6.9.4
 Requires PHP: 7.4
-Stable tag: 5.4.14
+Stable tag: 5.4.15
 License: GPLv2 or later
 License URI: http://www.gnu.org/licenses/gpl-2.0.html
 
@@ -47,6 +47,8 @@ By following these steps, you'll successfully install and configure the Conekta 
 `/assets/screenshot-2.png`
 
 == Changelog ==
+= 5.4.15 =
+* Fix: `ckpg_build_tax_lines` now reads `tax_total`/`shipping_tax_total` from `WC_Order_Item_Tax` objects (WooCommerce 3.0+), so IVA over items and shipping is reported correctly to Conekta instead of being collapsed into a "Round Adjustment" line
 = 5.4.14 =
 * Fix: Webhook `order.paid`/`order.expired` now uses `wc_get_order()` with fallback lookup by `conekta-order-id` meta, fixing HPOS compatibility and 3DS temp order mismatch
 * Fix: `validate_reference_id` now rejects empty, non-numeric, zero, and negative values

--- a/tests/WC_Conekta_Gateway_Test.php
+++ b/tests/WC_Conekta_Gateway_Test.php
@@ -1626,16 +1626,145 @@ class WC_Conekta_Gateway_Test extends TestCase
         $this->assertEquals(300, $result[1]['amount']);
     }
 
-    public function test_build_tax_lines_zero_amount()
+    public function test_build_tax_lines_zero_amount_is_omitted()
     {
+        // Zero-amount taxes should NOT be sent to Conekta.
         $taxes = [
             ['tax_amount' => 0, 'label' => 'Exempt'],
         ];
 
         $result = ckpg_build_tax_lines($taxes);
 
+        $this->assertEmpty($result, 'Zero-amount tax should be omitted from tax_lines');
+    }
+
+    public function test_build_tax_lines_zero_items_with_nonzero_shipping_emits_only_shipping()
+    {
+        $taxes = [
+            new WC_Order_Item_Tax([
+                'label'              => 'IVA',
+                'tax_total'          => 0,
+                'shipping_tax_total' => 2.40,
+            ]),
+        ];
+
+        $result = ckpg_build_tax_lines($taxes);
+
         $this->assertCount(1, $result);
-        $this->assertEquals(0, $result[0]['amount']);
+        $this->assertEquals('Shipping tax', $result[0]['description']);
+        $this->assertEquals(240, $result[0]['amount']);
+    }
+
+    // -------------------------------------------------------
+    // BE-839: ckpg_build_tax_lines must accept real WC_Order_Item_Tax objects
+    // -------------------------------------------------------
+
+    /**
+     * Real WooCommerce >= 3.0 returns WC_Order_Item_Tax objects from
+     * $order->get_taxes(). Those objects expose `tax_total`/`shipping_tax_total`
+     * via ArrayAccess — NOT the legacy `tax_amount`/`shipping_tax_amount` keys.
+     */
+    public function test_build_tax_lines_reads_tax_total_from_wc_order_item_tax()
+    {
+        $taxes = [
+            new WC_Order_Item_Tax([
+                'label'     => 'IVA',
+                'tax_total' => 16.00,
+            ]),
+        ];
+
+        $result = ckpg_build_tax_lines($taxes);
+
+        $this->assertCount(1, $result);
+        $this->assertEquals('IVA', $result[0]['description']);
+        $this->assertEquals(1600, $result[0]['amount'], 'IVA over items must be 1600 cents, not 0');
+    }
+
+    public function test_build_tax_lines_reads_shipping_tax_total_from_wc_order_item_tax()
+    {
+        $taxes = [
+            new WC_Order_Item_Tax([
+                'label'              => 'IVA',
+                'tax_total'          => 16.00,
+                'shipping_tax_total' => 2.40,
+            ]),
+        ];
+
+        $result = ckpg_build_tax_lines($taxes);
+
+        $this->assertCount(2, $result);
+        $this->assertEquals('IVA', $result[0]['description']);
+        $this->assertEquals(1600, $result[0]['amount']);
+        $this->assertEquals('Shipping tax', $result[1]['description']);
+        $this->assertEquals(240, $result[1]['amount'], 'Shipping IVA must be 240 cents, not 0');
+    }
+
+    public function test_build_tax_lines_omits_zero_shipping_tax_from_object()
+    {
+        // A WC_Order_Item_Tax always exposes shipping_tax_total (defaults to 0).
+        // We should NOT emit a "Shipping tax" line when the value is 0.
+        $taxes = [
+            new WC_Order_Item_Tax([
+                'label'              => 'IVA',
+                'tax_total'          => 16.00,
+                'shipping_tax_total' => 0,
+            ]),
+        ];
+
+        $result = ckpg_build_tax_lines($taxes);
+
+        $this->assertCount(1, $result, 'Zero shipping_tax_total should not produce a Shipping tax line');
+        $this->assertEquals('IVA', $result[0]['description']);
+        $this->assertEquals(1600, $result[0]['amount']);
+    }
+
+    public function test_build_tax_lines_multiple_real_objects()
+    {
+        $taxes = [
+            new WC_Order_Item_Tax([
+                'label'              => 'IVA',
+                'tax_total'          => 16.00,
+                'shipping_tax_total' => 2.40,
+            ]),
+            new WC_Order_Item_Tax([
+                'label'     => 'IEPS',
+                'tax_total' => 3.00,
+            ]),
+        ];
+
+        $result = ckpg_build_tax_lines($taxes);
+
+        $this->assertCount(3, $result); // IVA + Shipping tax + IEPS
+        $this->assertEquals('IVA', $result[0]['description']);
+        $this->assertEquals(1600, $result[0]['amount']);
+        $this->assertEquals('Shipping tax', $result[1]['description']);
+        $this->assertEquals(240, $result[1]['amount']);
+        $this->assertEquals('IEPS', $result[2]['description']);
+        $this->assertEquals(300, $result[2]['amount']);
+    }
+
+    /**
+     * End-to-end: $order->get_taxes() returns WC_Order_Item_Tax objects and the
+     * resulting tax_lines must carry the correct IVA amount, NOT 0.
+     */
+    public function test_order_taxes_pipeline_reports_iva_for_items_and_shipping()
+    {
+        $order = new WC_Order(700);
+        $order->set_taxes([
+            new WC_Order_Item_Tax([
+                'label'              => 'IVA',
+                'tax_total'          => 80.00,   // IVA over items
+                'shipping_tax_total' => 16.00,   // IVA over shipping
+            ]),
+        ]);
+
+        $tax_lines = ckpg_build_tax_lines($order->get_taxes());
+
+        $this->assertCount(2, $tax_lines);
+        $this->assertEquals('IVA', $tax_lines[0]['description']);
+        $this->assertEquals(8000, $tax_lines[0]['amount']);
+        $this->assertEquals('Shipping tax', $tax_lines[1]['description']);
+        $this->assertEquals(1600, $tax_lines[1]['amount']);
     }
 
     // -------------------------------------------------------

--- a/tests/bootstrap.php
+++ b/tests/bootstrap.php
@@ -194,7 +194,7 @@ if (!class_exists('WC_Payment_Gateway')) {
 // WC_Order_Item_Tax stub — emulates the ArrayAccess interface of WC 3.0+
 if (!class_exists('WC_Order_Item_Tax')) {
     class WC_Order_Item_Tax implements ArrayAccess {
-        private array $data;
+        private $data;
 
         public function __construct(array $data = []) {
             $this->data = array_merge([
@@ -215,7 +215,8 @@ if (!class_exists('WC_Order_Item_Tax')) {
         public function get_rate_id() { return $this->data['rate_id']; }
 
         public function offsetExists($offset): bool { return array_key_exists($offset, $this->data); }
-        public function offsetGet($offset): mixed { return $this->data[$offset] ?? null; }
+        #[\ReturnTypeWillChange]
+        public function offsetGet($offset) { return $this->data[$offset] ?? null; }
         public function offsetSet($offset, $value): void { $this->data[$offset] = $value; }
         public function offsetUnset($offset): void { unset($this->data[$offset]); }
     }

--- a/tests/bootstrap.php
+++ b/tests/bootstrap.php
@@ -191,6 +191,36 @@ if (!class_exists('WC_Payment_Gateway')) {
     }
 }
 
+// WC_Order_Item_Tax stub — emulates the ArrayAccess interface of WC 3.0+
+if (!class_exists('WC_Order_Item_Tax')) {
+    class WC_Order_Item_Tax implements ArrayAccess {
+        private array $data;
+
+        public function __construct(array $data = []) {
+            $this->data = array_merge([
+                'rate_code'          => '',
+                'rate_id'            => 0,
+                'label'              => '',
+                'compound'           => false,
+                'tax_total'          => 0,
+                'shipping_tax_total' => 0,
+                'rate_percent'       => 0,
+            ], $data);
+        }
+
+        public function get_label() { return $this->data['label']; }
+        public function get_tax_total() { return $this->data['tax_total']; }
+        public function get_shipping_tax_total() { return $this->data['shipping_tax_total']; }
+        public function get_rate_code() { return $this->data['rate_code']; }
+        public function get_rate_id() { return $this->data['rate_id']; }
+
+        public function offsetExists($offset): bool { return array_key_exists($offset, $this->data); }
+        public function offsetGet($offset): mixed { return $this->data[$offset] ?? null; }
+        public function offsetSet($offset, $value): void { $this->data[$offset] = $value; }
+        public function offsetUnset($offset): void { unset($this->data[$offset]); }
+    }
+}
+
 // WC_Order stub
 if (!class_exists('WC_Order')) {
     class WC_Order {
@@ -198,6 +228,7 @@ if (!class_exists('WC_Order')) {
         private $status = 'pending';
         private $meta = [];
         private $coupons = [];
+        private $taxes = [];
 
         public function __construct($id = 0) {
             $this->id = $id;
@@ -205,6 +236,10 @@ if (!class_exists('WC_Order')) {
 
         public function set_coupons(array $coupons) {
             $this->coupons = $coupons;
+        }
+
+        public function set_taxes(array $taxes) {
+            $this->taxes = $taxes;
         }
 
         public function get_id() { return $this->id; }
@@ -217,7 +252,7 @@ if (!class_exists('WC_Order')) {
             }
             return [];
         }
-        public function get_taxes() { return []; }
+        public function get_taxes() { return $this->taxes; }
         public function get_fees() { return []; }
 
         // Totals


### PR DESCRIPTION
## Summary
- Fix: `ckpg_build_tax_lines` ahora lee las llaves correctas (`tax_total` / `shipping_tax_total`) de los objetos `WC_Order_Item_Tax` de WooCommerce 3.0+. Antes leía las llaves legacy `tax_amount` / `shipping_tax_amount` que no existen en WC moderno, así que el IVA salía en 0 y terminaba enmascarado como "Round Adjustment" por el ajuste de balance.
- Skip: ahora se omiten tax_lines con monto 0 (items y shipping) para no mandar valores vacíos a Conekta.
- Bump: versión 5.4.14 → 5.4.15 con changelog correspondiente.

## Test plan
- [x] Tests unitarios nuevos cubriendo `WC_Order_Item_Tax` real (items, shipping, mixto, múltiples impuestos)
- [x] Tests confirman que un tax 0 NO se incluye en `tax_lines`
- [x] Suite completa pasa: 122/122 tests, 305 aserciones
- [ ] Probar manualmente un checkout con IVA configurado y verificar que el detalle de tax llega a Conekta con el monto correcto (no como "Round Adjustment")
- [ ] Validar checkout con shipping con IVA por separado

🤖 Generated with [Claude Code](https://claude.com/claude-code)