### PR TITLE
Potential fix for code scanning alert no. 29: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -4,6 +4,9 @@ on:
   release:
     types: [published]
 
+permissions:
+  contents: read
+
 jobs:
   tag-and-deploy:
     runs-on: ubuntu-latest


### PR DESCRIPTION
Potential fix for [https://github.com/conekta/ct-woocommerce-plugin/security/code-scanning/29](https://github.com/conekta/ct-woocommerce-plugin/security/code-scanning/29)

Add an explicit `permissions` block at the workflow root (best here since there is one job) with the minimum required scope:

- `contents: read`

This preserves existing functionality while enforcing least privilege for `GITHUB_TOKEN`.  
Edit only `.github/workflows/deploy.yml`, inserting the block after the `on:` trigger section and before `jobs:`.

No imports, methods, or extra definitions are needed.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
