### PR TITLE
fix(security): harden order.paid webhook against forged/replayed events

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,3 +1,7 @@
+6.2.2, 2026-08-18
+-------------------------------------
+- Security: harden the order.paid webhook against forged/replayed events (bind to the API-verified order, amount/currency check, idempotency per Conekta order).
+
 6.2.1, 2026-08-11
 -------------------------------------
 - Fix: on iOS Safari (classic checkout) the 3DS challenge could be unreachable — taps on the OTP field never landed because the loading overlay intercepted them. The overlay is now click-through while the rest of the form stays blocked during the charge.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,6 @@
+## [6.2.2]() - 2026-08-18
+- Security: harden the `order.paid` webhook against forged/replayed events (bind to the API-verified order, amount/currency check, idempotency per Conekta order).
+
 ## [6.2.1]() - 2026-08-11
 - Fix: on iOS Safari (classic checkout) the 3DS challenge could be unreachable — taps on the OTP field never landed because the loading overlay intercepted them. The overlay is now click-through while the rest of the form stays blocked during the charge.
 - Tests: new `safari-mobile` e2e shard (WebKit + iPhone emulation) that forces a 3DS challenge via `three_ds_mode=strict` and verifies the OTP is tappable.

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 <div align="center">
 
-# Conekta Woocommerce v.6.2.1
+# Conekta Woocommerce v.6.2.2
 [![Made with PHP](https://img.shields.io/badge/made%20with-php-red.svg?style=for-the-badge&colorA=ED4040&colorB=C12C2D)](http://php.net) 
 [![By Conekta](https://img.shields.io/badge/by-conekta-red.svg?style=for-the-badge&colorA=ee6130&colorB=00a4ac)](https://conekta.com)
 </div>

--- a/conekta_checkout.php
+++ b/conekta_checkout.php
@@ -4,7 +4,7 @@
 Plugin Name: Conekta Payment Gateway
 Plugin URI: https://wordpress.org/plugins/conekta-payment-gateway/
 Description: Payment Gateway through Conekta.io for WooCommerce: credit and debit cards, monthly installments (MSI) for Mexican cards, cash payments, bank transfers, buy now pay later (BNPL), and direct bank payments (pay by bank).
-Version: 6.2.1
+Version: 6.2.2
 Requires at least: 6.1
 Requires PHP: 7.4
 Author: Conekta.io

--- a/conekta_plugin.php
+++ b/conekta_plugin.php
@@ -28,7 +28,7 @@ class WC_Conekta_Plugin extends WC_Payment_Gateway
 	 */
 	public const API_CLIENT = 'woocommerce';
 
-	public $version  = "6.2.1";
+	public $version  = "6.2.2";
 	public $name = "WooCommerce 2";
 	public $description = "Payment Gateway via Conekta.io for WooCommerce: accepts credit and debit cards, monthly installments (MSI) for Mexican cards, cash, bank transfers, buy now pay later (BNPL), and direct bank payments (pay by bank).";
 	public $plugin_name = "Conekta Payment Gateway for Woocommerce";
@@ -104,22 +104,21 @@ class WC_Conekta_Plugin extends WC_Payment_Gateway
      */
     public static function handleOrderPaid(OrdersApi $ordersApi, array $event)
     {
-        $conekta_order = $event['data']['object'];
-        if (!self::validate_reference_id($conekta_order)) {
+        $payload          = $event['data']['object'] ?? [];
+        $conekta_order_id = isset($payload['id']) && is_string($payload['id']) ? $payload['id'] : '';
+        if ($conekta_order_id === '') {
             http_response_code(400);
             header('Content-Type: application/json');
             echo json_encode([
-                'error'  => 'Invalid order id: the event payload carries neither a numeric metadata.reference_id nor a Conekta order id, so the WooCommerce order cannot be resolved.',
+                'error'  => 'Invalid order id: the event payload carries no Conekta order id, so the payment cannot be verified.',
                 'source' => 'handleOrderPaid',
                 'event'  => $event['type'] ?? 'order.paid',
             ]);
             exit;
         }
 
-        // Never trust the event payload: re-read the payment status from the
-        // API. A mismatch here usually means the API is lagging the event —
-        // the 400 makes Conekta retry, and a later retry passes.
-        $api_payment_status = self::fetch_conekta_payment_status($ordersApi, $conekta_order['id']);
+        $verified_order     = self::fetch_conekta_order($ordersApi, $conekta_order_id);
+        $api_payment_status = (string) $verified_order->getPaymentStatus();
         if ($api_payment_status !== 'paid') {
             http_response_code(400);
             header('Content-Type: application/json');
@@ -131,12 +130,14 @@ class WC_Conekta_Plugin extends WC_Payment_Gateway
                 ),
                 'source'           => 'handleOrderPaid',
                 'event'            => $event['type'] ?? 'order.paid',
-                'conekta_order_id' => $conekta_order['id'] ?? null,
+                'conekta_order_id' => $conekta_order_id,
                 'payment_status'   => $api_payment_status,
                 'expected'         => ['paid'],
             ]);
             exit;
         }
+
+        $conekta_order = self::conekta_order_to_array($verified_order);
 
         $order = self::find_order_for_webhook($conekta_order);
         if (!$order) {
@@ -198,6 +199,60 @@ class WC_Conekta_Plugin extends WC_Payment_Gateway
                 'message'  => 'OK',
                 'order_id' => $order->get_id(),
                 'note'     => 'already paid (idempotent retry)',
+            ]);
+            exit;
+        }
+
+        $already_paid = self::find_paid_order_for_conekta_id($conekta_order_id, (int) $order->get_id());
+        if ($already_paid) {
+            error_log(sprintf(
+                'Conekta - handleOrderPaid: Conekta order %s already applied to WC order #%d; refusing to complete WC order #%d.',
+                $conekta_order_id,
+                $already_paid->get_id(),
+                $order->get_id()
+            ));
+            header('Content-Type: application/json');
+            echo json_encode([
+                'message'  => 'OK',
+                'order_id' => $already_paid->get_id(),
+                'note'     => sprintf('conekta order already applied to order #%d (idempotent, not completing twice)', $already_paid->get_id()),
+            ]);
+            exit;
+        }
+
+        // Amount + currency gate, mirroring the synchronous pre-charge gate
+        // (prepare_order_for_charge). The Conekta order was charged for a fixed
+        // amount; it MUST match the WooCommerce order being completed. A
+        // mismatch means this is not the order that was paid — refuse.
+        $expected_amount   = (int) round($order->get_total() * 100);
+        $actual_amount     = (int) $verified_order->getAmount();
+        $expected_currency = strtoupper((string) $order->get_currency());
+        $actual_currency   = strtoupper((string) $verified_order->getCurrency());
+        if ($expected_amount !== $actual_amount
+            || ($actual_currency !== '' && $expected_currency !== $actual_currency)) {
+            self::send_webhook_diagnostic($ordersApi, $conekta_order_id, 'mismatch_amount', array_filter([
+                'wc_order_id'       => (string) $order->get_id(),
+                'expected_amount'   => (string) $expected_amount,
+                'actual_amount'     => (string) $actual_amount,
+                'expected_currency' => $expected_currency,
+                'actual_currency'   => $actual_currency,
+            ]));
+            error_log(sprintf(
+                'Conekta - handleOrderPaid: AMOUNT/CURRENCY MISMATCH — WC order #%d expects %d %s, Conekta order %s holds %d %s. NOT completing.',
+                $order->get_id(),
+                $expected_amount,
+                $expected_currency,
+                $conekta_order_id,
+                $actual_amount,
+                $actual_currency
+            ));
+            http_response_code(409);
+            header('Content-Type: application/json');
+            echo json_encode([
+                'error'    => 'Amount/currency mismatch: the paid Conekta order does not match this WooCommerce order. Not completing.',
+                'order_id' => $order->get_id(),
+                'expected' => ['amount' => $expected_amount, 'currency' => $expected_currency],
+                'actual'   => ['amount' => $actual_amount, 'currency' => $actual_currency],
             ]);
             exit;
         }
@@ -479,9 +534,40 @@ class WC_Conekta_Plugin extends WC_Payment_Gateway
      */
     public static function fetch_conekta_payment_status(OrdersApi $ordersApi, string $conekta_order_id): string
     {
-        $conekta_order_api = $ordersApi->getorderbyid($conekta_order_id, 'es', null, self::API_CLIENT);
+        return (string) self::fetch_conekta_order($ordersApi, $conekta_order_id)->getPaymentStatus();
+    }
 
-        return (string) $conekta_order_api->getPaymentStatus();
+    public static function fetch_conekta_order(OrdersApi $ordersApi, string $conekta_order_id)
+    {
+        return $ordersApi->getOrderById($conekta_order_id, 'es', null, self::API_CLIENT);
+    }
+
+    public static function conekta_order_to_array($conekta_order): array
+    {
+        if (is_array($conekta_order)) {
+            return $conekta_order;
+        }
+        $data = json_decode(json_encode($conekta_order), true);
+        return is_array($data) ? $data : [];
+    }
+
+    public static function find_paid_order_for_conekta_id(string $conekta_order_id, int $exclude_order_id)
+    {
+        if ($conekta_order_id === '') {
+            return false;
+        }
+        $orders = wc_get_orders([
+            'meta_key'   => 'conekta-order-id',
+            'meta_value' => $conekta_order_id,
+            'exclude'    => [$exclude_order_id],
+            'limit'      => 10,
+        ]);
+        foreach ($orders as $candidate) {
+            if (in_array($candidate->get_status(), ['processing', 'completed'], true)) {
+                return $candidate;
+            }
+        }
+        return false;
     }
 
     /**

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "conekta-payment-gateway",
-  "version": "6.2.1",
+  "version": "6.2.2",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "conekta-payment-gateway",
-      "version": "6.2.1",
+      "version": "6.2.2",
       "license": "ISC",
       "dependencies": {
         "@woocommerce/settings": "^1.0.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "conekta-payment-gateway",
-  "version": "6.2.1",
+  "version": "6.2.2",
   "description": "<div align=\"center\">",
   "main": "index.js",
   "directories": {

--- a/readme.txt
+++ b/readme.txt
@@ -4,7 +4,7 @@ Tags: free, cash, conekta, mexico, payment gateway
 Requires at least: 6.1
 Tested up to: 7.0
 Requires PHP: 7.4
-Stable tag: 6.2.1
+Stable tag: 6.2.2
 License: GPLv2 or later
 License URI: http://www.gnu.org/licenses/gpl-2.0.html
 
@@ -47,6 +47,9 @@ By following these steps, you'll successfully install and configure the Conekta 
 `/assets/screenshot-2.png`
 
 == Changelog ==
+= 6.2.2 =
+* Security: harden the order.paid webhook against forged/replayed events (bind to the API-verified order, amount/currency check, idempotency per Conekta order).
+
 = 6.2.1 =
 * Fix: on iOS Safari (classic checkout) the 3DS challenge could be unreachable — taps on the OTP field never landed because the loading overlay intercepted them. The overlay now lets the interaction through while the rest of the form stays blocked during the charge.
 

--- a/tests/WC_Conekta_Gateway_Test.php
+++ b/tests/WC_Conekta_Gateway_Test.php
@@ -342,6 +342,112 @@ class WC_Conekta_Gateway_Test extends TestCase
     }
 
     // -------------------------------------------------------
+    // Webhook idempotency — find_paid_order_for_conekta_id()
+    // -------------------------------------------------------
+
+    /**
+     * A paid Conekta order must complete at most one WC order: when another
+     * PAID order already carries the conekta-order-id, the helper surfaces it
+     * so handleOrderPaid refuses to complete a second one (replay defense).
+     */
+    public function test_find_paid_order_for_conekta_id_returns_other_paid_order()
+    {
+        global $test_order_registry;
+        $test_order_registry = [];
+
+        $paid = new WC_Order(2001);
+        $paid->set_status('processing');
+        $paid->update_meta_data('conekta-order-id', 'ord_shared');
+        $test_order_registry[2001] = $paid;
+
+        $target = new WC_Order(2002);
+        $target->set_status('pending');
+        $target->update_meta_data('conekta-order-id', 'ord_shared');
+        $test_order_registry[2002] = $target;
+
+        $found = WC_Conekta_Plugin::find_paid_order_for_conekta_id('ord_shared', 2002);
+        $this->assertNotFalse($found, 'A paid order owning the same conekta id must be surfaced');
+        $this->assertEquals(2001, $found->get_id());
+    }
+
+    /**
+     * A pending order sharing the conekta-order-id is a normal order-first
+     * retry leftover (the meta is stamped BEFORE the charge), NOT a double
+     * payment — it must not block completion.
+     */
+    public function test_find_paid_order_for_conekta_id_ignores_pending_sibling()
+    {
+        global $test_order_registry;
+        $test_order_registry = [];
+
+        $sibling = new WC_Order(2010);
+        $sibling->set_status('pending');
+        $sibling->update_meta_data('conekta-order-id', 'ord_pendingdup');
+        $test_order_registry[2010] = $sibling;
+
+        $target = new WC_Order(2011);
+        $target->set_status('pending');
+        $target->update_meta_data('conekta-order-id', 'ord_pendingdup');
+        $test_order_registry[2011] = $target;
+
+        $this->assertFalse(WC_Conekta_Plugin::find_paid_order_for_conekta_id('ord_pendingdup', 2011));
+    }
+
+    /**
+     * The order being completed is excluded from its own duplicate check.
+     */
+    public function test_find_paid_order_for_conekta_id_excludes_self()
+    {
+        global $test_order_registry;
+        $test_order_registry = [];
+
+        $self = new WC_Order(2020);
+        $self->set_status('processing');
+        $self->update_meta_data('conekta-order-id', 'ord_self');
+        $test_order_registry[2020] = $self;
+
+        $this->assertFalse(WC_Conekta_Plugin::find_paid_order_for_conekta_id('ord_self', 2020));
+    }
+
+    // -------------------------------------------------------
+    // Trusted payload conversion — conekta_order_to_array()
+    // -------------------------------------------------------
+
+    /**
+     * The API-fetched OrderResponse must serialize into the same array shape
+     * the webhook helpers consume, carrying the TRUSTED fields (id, amount,
+     * currency, metadata) — this is the object the webhook path uses instead
+     * of the attacker-controlled event body.
+     */
+    public function test_conekta_order_to_array_from_api_object()
+    {
+        $object = new \Conekta\Model\OrderResponse([
+            'id'             => 'ord_trusted',
+            'amount'         => 15000,
+            'currency'       => 'MXN',
+            'payment_status' => 'paid',
+            'metadata'       => ['reference_id' => '4242'],
+        ]);
+
+        $array = WC_Conekta_Plugin::conekta_order_to_array($object);
+
+        $this->assertIsArray($array);
+        $this->assertEquals('ord_trusted', $array['id']);
+        $this->assertEquals(15000, $array['amount']);
+        $this->assertEquals('MXN', $array['currency']);
+        $this->assertEquals('4242', $array['metadata']['reference_id']);
+    }
+
+    /**
+     * An array is returned unchanged (idempotent).
+     */
+    public function test_conekta_order_to_array_passes_arrays_through()
+    {
+        $array = ['id' => 'ord_x', 'metadata' => ['reference_id' => '7']];
+        $this->assertSame($array, WC_Conekta_Plugin::conekta_order_to_array($array));
+    }
+
+    // -------------------------------------------------------
     // get_blocks_draft_order_id — the blocks-only WC order id
     // written into the Conekta order metadata as reference_id.
     // -------------------------------------------------------


### PR DESCRIPTION
## Summary

The `order.paid` webhook (`?wc-api=wc_conekta` and the four other gateway endpoints) trusted the unauthenticated event body. It re-read only the payment **status** from the Conekta API, then selected the WooCommerce order from the payload's `metadata.reference_id` — with no binding of the verified Conekta order to that WC order and no amount comparison — before calling `payment_complete()`. An attacker who owns a single genuinely-paid Conekta order id could replay it in a forged event against any unpaid WC order, marking it paid for free, and reuse the id across orders.

All five gateways funnel through the same static `handleOrderPaid()` in `conekta_plugin.php`, so the fix lives in one place.

## Changes

- **Bind to the API-verified order.** The event body is used **only** for the Conekta order id, which is immediately re-verified against the API. `reference_id`, `amount`, `currency` and `metadata` now come from the API-fetched object (`conekta_order_to_array()`), never the payload. A replayed paid order can only resolve back to its own WC order.
- **Amount + currency gate** before completing, mirroring the synchronous pre-charge gate in `prepare_order_for_charge`.
- **Idempotency keyed on the Conekta order id** (`find_paid_order_for_conekta_id()`) so one paid order can never complete more than one WC order.
- Version bump to **6.2.2**.

### Wallets (Apple/Google Pay)
Binding does not depend on `reference_id` (often absent for wallet charges): resolution falls back to the reverse `conekta-order-id` meta the plugin itself stamps during checkout — a server-side fact the attacker cannot forge.

### Out of scope (deliberate)
- IP allowlisting — unreliable behind proxies/CDNs on merchant hosting.
- `handleOrderExpiredOrCanceled` shares the pattern but can only *cancel* (not mark paid), already re-reads status, and has a stale-order guard.

## Tests
5 new unit tests (idempotency helper + trusted-object conversion). Full suite green: 224 tests, 527 assertions (9 pre-existing skips require the local mock server).

🤖 Generated with [Claude Code](https://claude.com/claude-code)